### PR TITLE
fixes typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ When bundling:
 
 ```js
 var fs = require('fs');
-var browerify = require('browerify');
+var browserify = require('browserify');
 var brjade = require('brjade');
 
 browserify('index.js')


### PR DESCRIPTION
Fixes typo so people can copy the example and run it without errors.
